### PR TITLE
Fix bazel build (#1)

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -15,10 +15,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-new_http_archive(
+workspace(name = "com_github_tetsuok_arowpp")
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")
+
+http_archive(
     name = "gtest",
-    url = "https://googletest.googlecode.com/files/gtest-1.7.0.zip",
-    sha256 = "247ca18dd83f53deb1328be17e4b1be31514cedfc1e3424f672bf11fd7e0d60d",
-    build_file = "gtest.BUILD",
-    strip_prefix = "gtest-1.7.0",
+    url = "https://github.com/google/googletest/archive/release-1.7.0.zip",
+    sha256 = "b58cb7547a28b2c718d1e38aee18a3659c9e3ff52440297e965f5edffe34b6d0",
+    build_file = "@//:gtest.BUILD",
+    strip_prefix = "googletest-release-1.7.0",
 )


### PR DESCRIPTION
* Use http_archive to fix the build issues in recent bazel version as new_http_archive was deprecated [1].
* Update the URL for gtest.

[1] https://groups.google.com/d/topic/bazel-discuss/dO2MHQLwJF0/discussion